### PR TITLE
feat: useModal 추가 #29

### DIFF
--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,60 @@
+import { HTMLAttributes } from "react";
+import Modal from "../components/common/Modals/Modal";
+import useToggle from "./useToggle";
+import { HStack, VStack } from "../components/common/Stack";
+import Button from "../components/common/Button";
+import cn from "../utils/cn";
+
+interface ModalProps extends HTMLAttributes<HTMLDivElement> {
+  dark?: boolean;
+  hideBackDrop?: boolean;
+  modalType?: "modal" | "sheet";
+}
+
+// const { modal, triggerModal } = useModal(message, onConfirm);
+// 세번째 필드로 취소 가능한지 넣을 수 있음
+// 네번째 필드는 모달 모양 관련 구조체
+// 맨 아래쪽에 {modal} 만 넣어주면 됨
+
+export function useModal(
+  message: string,
+  onConfirm: () => void = () => {},
+  cancellable: boolean = true,
+  modalProps: ModalProps = {}
+) {
+  const [show, toggleShow] = useToggle();
+  const confirm = () => {
+    onConfirm();
+    toggleShow();
+  };
+  const modal = (
+    <Modal
+      {...modalProps}
+      backDrop={cancellable}
+      xButton={cancellable}
+      show={show}
+      onClose={toggleShow}
+    >
+      <VStack
+        className={cn(
+          "items-center gap-8",
+          modalProps.modalType === "sheet" ? "w-full" : "w-72"
+        )}
+      >
+        <span className={modalProps.dark ? "text-white" : ""}>{message}</span>
+        <HStack className="w-full">
+          {cancellable && (
+            <Button gray roundedFull onClick={toggleShow}>
+              취소
+            </Button>
+          )}
+          <Button className="flex-grow" roundedFull onClick={confirm}>
+            확인
+          </Button>
+        </HStack>
+      </VStack>
+    </Modal>
+  );
+
+  return { modal, triggerModal: toggleShow };
+}


### PR DESCRIPTION
## 풀 리퀘스트 유형
<!-- 이 PR이 어떤 종류의 변경을 도입합니까? -->
<!-- 이 PR에 해당하는 것을 "x"를 사용하여 확인하십시오. -->
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 업데이트 (서식, 로컬 변수)
- [ ] 리팩토링 (기능적 변경 없음, API 변경 없음)
- [ ] 빌드 관련 변경
- [ ] CI 관련 변경
- [ ] 문서 내용 변경
- [ ] 기타... 설명:

<br/>


## 새로운 기능

* useModal - 취소여부, 확인 액션 정도만 추가 가능한 모달 생성 훅
```
  const { modal, triggerModal } = useModal(
    "ㅎㅇㅎㅇ", // 메시지
    () => {alert("확인 누름");}, // 확인 버튼 누를 시 동작
    false, // 취소 여부, 안넣어도 됨
    {modalType:"modal", dark:true} // 기타 설정, 안넣어도 됨
  );
```

```
    <>
      {modal}  ← 이런식으로 넣으면 됨
      <VStack className="!gap-0 bg-gradient-to-b from-[#e3e7e9] to-[#ffffff] min-h-full pt-4">
        {/* 상단 바로가기메뉴 (이름, 원큐지갑, QR, 알림) */}
        <VStack className="px-6">
        ...
```
<img width="287" alt="스크린샷 2024-05-31 오후 5 43 46" src="https://github.com/Hanaro-trip-together-bank/front/assets/74809873/41fa9536-5315-46f1-bc37-423ce7e52178">

## 기타 정보

<br/>
